### PR TITLE
Fixing rat and spotless on Jenkins builds

### DIFF
--- a/.ratignore
+++ b/.ratignore
@@ -1,3 +1,4 @@
+**/\?/
 **/.gitattributes
 **/.gitignore
 .ratignore

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,7 +192,7 @@ allprojects {
                 // See https://github.com/diffplug/spotless/issues/468
                 format("markdown") {
                     target("**/*.md")
-					targetExclude("?/**") // do not check markdown files in Jenkins "?" directory
+                    targetExclude("?/**") // do not check markdown files in Jenkins "?" directory
                     // Flot is known to have trailing whitespace, so the files
                     // are kept in their original format (e.g. to simplify diff on library upgrade)
                     trimTrailingWhitespace()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,6 +192,7 @@ allprojects {
                 // See https://github.com/diffplug/spotless/issues/468
                 format("markdown") {
                     target("**/*.md")
+					targetExclude("\?/**") // do not check markdown files in Jenkins "?" directory
                     // Flot is known to have trailing whitespace, so the files
                     // are kept in their original format (e.g. to simplify diff on library upgrade)
                     trimTrailingWhitespace()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,7 +192,7 @@ allprojects {
                 // See https://github.com/diffplug/spotless/issues/468
                 format("markdown") {
                     target("**/*.md")
-					targetExclude("\?/**") // do not check markdown files in Jenkins "?" directory
+					targetExclude("?/**") // do not check markdown files in Jenkins "?" directory
                     // Flot is known to have trailing whitespace, so the files
                     // are kept in their original format (e.g. to simplify diff on library upgrade)
                     trimTrailingWhitespace()


### PR DESCRIPTION
In the Jenkins workfolder, the folder "?" exists. Files in that folder are then checked by rat and spotless leading to failing builds.
Excluding the folder fixes this problem.